### PR TITLE
Updating forecast.io URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # weather
 
-Weather via the command line. Uses the [forecast.io](forecast.io) API so it's super accurate. Also includes any current weather alerts in the output.
+Weather via the command line. Uses the [forecast.io](http://forecast.io) API so it's super accurate. Also includes any current weather alerts in the output.
 
 ![Screenshot](screenshot.png)
 


### PR DESCRIPTION
Super cool project!!

I noticed that the URL for forecast.io in the project README 404s when you follow it:
![forecastio](https://cloud.githubusercontent.com/assets/274668/4546053/268e5b12-4e40-11e4-996f-8a54c257e62f.png)

I stuck an "http://" on that URL and it works as advertised.

Thanks for sharing this work!
