### PR TITLE
Add missing "uk2" unit

### DIFF
--- a/forecast/print.go
+++ b/forecast/print.go
@@ -40,10 +40,17 @@ var (
 			Length:        "kilometers",
 			Precipitation: "mm/h",
 		},
+		// deprecated, use "uk2" in stead
 		"uk": UnitMeasures{
 			Degrees:       "°C",
 			Speed:         "mph",
 			Length:        "kilometers",
+			Precipitation: "mm/h",
+		},
+		"uk2": UnitMeasures{
+			Degrees:       "°C",
+			Speed:         "mph",
+			Length:        "miles",
 			Precipitation: "mm/h",
 		},
 	}


### PR DESCRIPTION
The "uk" unit [is deprecated](https://developer.forecast.io/docs/v2#options) and the "uk2" unit should be used in stead.