### PR TITLE
Fix for changing the Forecast Offset type to a float64

### DIFF
--- a/forecast/forecast.go
+++ b/forecast/forecast.go
@@ -136,7 +136,7 @@ type Forecast struct {
 	Hourly    TimeDelimited `json:"hourly"`
 	Latitude  float64       `json:"latitude"`
 	Longitude float64       `json:"longitude"`
-	Offset    int           `json:"offset"`
+	Offset    float64       `json:"offset"`
 	Timezone  string        `json:"timezone"`
 }
 


### PR DESCRIPTION
Changed the type for Forecast struct's Offset var to a float64.
This is a fix for issue #26 to support timezones like , for eg., India, which have an offset of 5.5