### PR TITLE
Add emoji icons for printing given a parameter

### DIFF
--- a/forecast/print.go
+++ b/forecast/print.go
@@ -141,6 +141,51 @@ func getIcon(iconStr string) (icon string, err error) {
 	return colorstring.Color("[" + color + "]" + icon), nil
 }
 
+func getEmojiIcon(iconStr string) (icon string, err error) {
+	color := "white"
+	// steralize the icon string name
+	iconStr = strings.Replace(strings.Replace(iconStr, "-", "", -1), "_", "", -1)
+
+	switch iconStr {
+	case "clear":
+		icon = "🔆"
+	case "clearday":
+		icon = "🔆"
+	case "clearnight":
+		icon = "🌙"
+	case "clouds":
+		icon = "☁️"
+	case "cloudy":
+		icon = "☁️"
+	case "cloudsnight":
+		icon = "☁️"
+	case "fog":
+		icon = "🌫️"
+	case "haze":
+		icon = "🌫️"
+	case "hazenight":
+		icon = "🌫️"
+	case "partlycloudyday":
+		icon = "⛅️"
+	case "partlycloudynight":
+		icon = "⛅️"
+	case "rain":
+		icon = "🌧"
+	case "sleet":
+		icon = "🌨"
+	case "snow":
+		icon = "🌨"
+	case "thunderstorm":
+		icon = "⛈"
+	case "tornado":
+		icon = "🌪"
+	case "wind":
+		icon = "💨"
+	}
+
+	return colorstring.Color("[" + color + "]" + "\n" + icon), nil
+}
+
 func getBearingDetails(degrees float64) string {
 	index := int(math.Mod((degrees+11.25)/22.5, 16))
 	return Directions[index]
@@ -212,11 +257,18 @@ func kmToMile(km float64) float64 {
 }
 
 // PrintCurrent pretty prints the current forecast data.
-func PrintCurrent(forecast Forecast, geolocation geocode.Geocode, ignoreAlerts bool, hideIcon bool) error {
+func PrintCurrent(forecast Forecast, geolocation geocode.Geocode, ignoreAlerts bool, hideIcon bool, emojiIcons bool) error {
 	unitsFormat := UnitFormats[forecast.Flags.Units]
 
 	if !hideIcon {
-		icon, err := getIcon(forecast.Currently.Icon)
+		var err error
+		var icon string
+
+		if emojiIcons {
+			icon, err = getEmojiIcon(forecast.Currently.Icon)
+		} else {
+			icon, err = getIcon(forecast.Currently.Icon)
+		}
 		if err != nil {
 			return err
 		}

--- a/forecast/print.go
+++ b/forecast/print.go
@@ -257,7 +257,7 @@ func kmToMile(km float64) float64 {
 }
 
 // PrintCurrent pretty prints the current forecast data.
-func PrintCurrent(forecast Forecast, geolocation geocode.Geocode, ignoreAlerts bool, hideIcon bool, emojiIcons bool) error {
+func PrintCurrent(forecast Forecast, geolocation geocode.Geocode, ignoreAlerts, hideIcon, emojiIcons bool) error {
 	unitsFormat := UnitFormats[forecast.Flags.Units]
 
 	if !hideIcon {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var (
 	days         int
 	ignoreAlerts bool
 	hideIcon     bool
+	emojiIcons   bool
 	noForecast   bool
 	jsonOut      bool
 	server       string
@@ -70,6 +71,7 @@ func main() {
 
 	p.FlagSet.BoolVar(&ignoreAlerts, "ignore-alerts", false, "Ignore alerts in weather output")
 	p.FlagSet.BoolVar(&hideIcon, "hide-icon", false, "Hide the weather icons from being output")
+	p.FlagSet.BoolVar(&emojiIcons, "use-emoji-icon", false, "Use emojis for weather icons")
 	p.FlagSet.BoolVar(&noForecast, "no-forecast", false, "Hide the forecast for the next 16 hours")
 
 	p.FlagSet.BoolVar(&jsonOut, "json", false, "Prints the raw JSON API response")
@@ -144,7 +146,7 @@ func main() {
 			return nil
 		}
 
-		if err := forecast.PrintCurrent(fc, geo, ignoreAlerts, hideIcon); err != nil {
+		if err := forecast.PrintCurrent(fc, geo, ignoreAlerts, hideIcon, emojiIcons); err != nil {
 			printError(err)
 		}
 


### PR DESCRIPTION
This pull requests adds support for printing emoji icons instead of the ASCII/SVG icons. 
The parameter `--use-emoji-icon` has been added along with a switch statement for the different emojis (based on the existing code). 

I'm new to Go so I'm unsure if the error handling in https://github.com/genuinetools/weather/blob/818d1adc47cc1fa930a0b631148cdf4fc41e84f5/forecast/print.go#L264-L274 is correct. Let me know! 