### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For installation instructions from binaries please visit the [Releases Page](htt
 #### Via Go
 
 ```console
-$ go get github.com/genuinetools/weather
+$ go install github.com/genuinetools/weather@latest
 ```
 
 #### Via Homebrew


### PR DESCRIPTION
The installation instructions are outdated since go doesn't support go get anymore and requires a version to be specified.